### PR TITLE
Branch alias for v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
     },
     "autoload": {
         "files": ["autoload.php"]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-develop-2": "2.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This helps to get rid of writing 

``` json
{
    "aura/package": "dev-develop-2"
}
```

Something like

``` json
{
    "aura/package": "2.*"
}
```
