### PR TITLE
Fix params passed to invokeMethod() in Intercessory Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ class Blog
         $params = $this->request->params;
         $action = isset($params['action']) ? $params['action'] : 'index';
         $method = 'action' . ucfirst($action);
-        return $this->invokeMethod($pathinfo, $this, $method);
+        return $this->invokeMethod($this, $method, $params);
     }
     
     protected function actionRead($id = null)


### PR DESCRIPTION
Expect object, method, params. Tested in an example and this appears to be correct now.
