### PR TITLE
Fix #14 - remove stray duplicate DocBlock.

### DIFF
--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -50,16 +50,6 @@ interface DispatcherInterface
      * 
      */
     public function getObjectParam();
-    
-    /**
-     * 
-     * Sets the parameter indicating the dispatchable object name.
-     * 
-     * @param string $object_param The parameter name to use.
-     * 
-     * @return null
-     * 
-     */
      
     /**
      * 


### PR DESCRIPTION
Paul, for what it's worth: there's a lot of trailing whitespace in this file. I had to temporarily disable auto-trim in Sublime to PR properly.
