### PR TITLE
Support __call magic method on objects

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -113,7 +113,7 @@ class Dispatcher implements DispatcherInterface
     protected function dispatch($object, $params = [])
     {
         $method = $this->getMethodByParams($params);
-        if (is_callable([$object, $method]) && method_exists($object, $method)) {
+        if (is_callable([$object, $method])) {
             // the object has the specified method
             $result = $this->invokeMethod($object, $method, $params);
         } elseif ($object instanceof Closure) {

--- a/src/InvokeMethodTrait.php
+++ b/src/InvokeMethodTrait.php
@@ -42,13 +42,19 @@ trait InvokeMethodTrait
     protected function invokeMethod($object, $method, $params = [])
     {
         // is the method defined?
-        if (! method_exists($object, $method)) {
+        if (! is_callable([$object, $method])) {
             $message = get_class($object) . '::' . $method;
             throw new Exception\MethodNotDefined($message);
         }
 
         // reflect on the object method
-        $reflect = new ReflectionMethod($object, $method);
+        try {
+            $reflect = new ReflectionMethod($object, $method);
+        } catch (\ReflectionException $e) {
+            // It doesn't have that method explicitly... if it has call, then this becomes easy!
+            $reflect = new ReflectionMethod($object, '__call');
+            return $object->__call($method, $params);
+        }
 
         // check accessibility from $this to honor protected/private methods
         $accessible = true;


### PR DESCRIPTION
This PR allows objects to have a magic `__call()` method as a catch-all for actions that aren't explicitly defined as methods.
