### PR TITLE
Support __call magic method on objects

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -113,7 +113,7 @@ class Dispatcher implements DispatcherInterface
     protected function dispatch($object, $params = [])
     {
         $method = $this->getMethodByParams($params);
-        if (is_callable([$object, $method]) && method_exists($object, $method)) {
+        if (is_callable([$object, $method])) {
             // the object has the specified method
             $result = $this->invokeMethod($object, $method, $params);
         } elseif ($object instanceof Closure) {

--- a/src/InvokeMethodTrait.php
+++ b/src/InvokeMethodTrait.php
@@ -43,6 +43,9 @@ trait InvokeMethodTrait
     {
         // is the method defined?
         if (! method_exists($object, $method)) {
+            if (method_exists($object, '__call')) {
+                return $object->__call($method, $params);
+            }
             $message = get_class($object) . '::' . $method;
             throw new Exception\MethodNotDefined($message);
         }


### PR DESCRIPTION
This PR allows objects to have a magic __call() method as a catch-all for actions that aren't explicitly defined as methods.

This is a simpler way than my previous PR, which I will close (and Scrutinizer made a very good point which this patch avoids).
