### PR TITLE
Tests for missing/inaccessible methods

### DIFF
--- a/tests/unit/src/DispatcherTest.php
+++ b/tests/unit/src/DispatcherTest.php
@@ -179,4 +179,26 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
         $expect = 'Hello World!';
         $this->assertSame($expect, $actual);
     }
+
+	public function testMethodNotDefined()
+	{
+		$params = [
+			'action' => 'missingMethod',
+			'controller' => 'factory'
+		];
+
+		$this->setExpectedException('Aura\Dispatcher\Exception\MethodNotDefined');
+		$actual = $this->dispatcher->__invoke($params);
+	}
+
+	public function testMethodNotAccessible()
+	{
+		$params = [
+			'action' => 'privateMethod',
+			'controller' => 'factory'
+		];
+
+		$this->setExpectedException('Aura\Dispatcher\Exception\MethodNotAccessible');
+		$actual = $this->dispatcher->__invoke($params);
+	}
 }

--- a/tests/unit/src/DispatcherTest.php
+++ b/tests/unit/src/DispatcherTest.php
@@ -180,25 +180,25 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
 
-	public function testMethodNotDefined()
-	{
-		$params = [
-			'action' => 'missingMethod',
-			'controller' => 'factory'
-		];
+    public function testMethodNotDefined()
+    {
+        $params = [
+            'action' => 'missingMethod',
+            'controller' => 'factory'
+        ];
 
-		$this->setExpectedException('Aura\Dispatcher\Exception\MethodNotDefined');
-		$actual = $this->dispatcher->__invoke($params);
-	}
+        $this->setExpectedException('Aura\Dispatcher\Exception\MethodNotDefined');
+        $actual = $this->dispatcher->__invoke($params);
+    }
 
-	public function testMethodNotAccessible()
-	{
-		$params = [
-			'action' => 'privateMethod',
-			'controller' => 'factory'
-		];
+    public function testMethodNotAccessible()
+    {
+        $params = [
+            'action' => 'privateMethod',
+            'controller' => 'factory'
+        ];
 
-		$this->setExpectedException('Aura\Dispatcher\Exception\MethodNotAccessible');
-		$actual = $this->dispatcher->__invoke($params);
-	}
+        $this->setExpectedException('Aura\Dispatcher\Exception\MethodNotAccessible');
+        $actual = $this->dispatcher->__invoke($params);
+    }
 }


### PR DESCRIPTION
Two new test that currently fail for not throwing the expected Exceptions if your action maps to a missing or private/protected method.  As mention in Issue #23. 
